### PR TITLE
Modified vcl-select to use the vcl-input-field.

### DIFF
--- a/demo/app/demos/select/demo.component.html
+++ b/demo/app/demos/select/demo.component.html
@@ -284,8 +284,7 @@
 <h3>Select with prepended icon</h3>
 <vcl-form-control-group>
   <vcl-label>Select country</vcl-label>
-  <vcl-select>
-    <vcl-icon prepend icon="vcl:search"></vcl-icon>
+  <vcl-select [showSearchIcon]="true">
     <vcl-select-list [(value)]="value8">
       <vcl-select-list-header>Europe</vcl-select-list-header>
       <vcl-select-list-item value="Greece">

--- a/lib/ng-vcl/src/input/input-field.component.ts
+++ b/lib/ng-vcl/src/input/input-field.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, OnDestroy, HostBinding, ContentChild, AfterContentInit, forwardRef, ChangeDetectorRef, ElementRef } from '@angular/core';
 import { InputDirective } from './input.directive';
 import { TextareaDirective } from './textarea.directive';
-import { Subscription, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { FORM_CONTROL_EMBEDDED_LABEL_INPUT, EmbeddedInputFieldLabelInput } from './embedded-label.directive';
 
 @Component({

--- a/lib/ng-vcl/src/input/input.directive.ts
+++ b/lib/ng-vcl/src/input/input.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostBinding, Input, HostListener, forwardRef, Optional, Inject, OnDestroy, InjectionToken, Injector } from '@angular/core';
+import { Directive, ElementRef, HostBinding, Input, HostListener, forwardRef, OnDestroy, Injector } from '@angular/core';
 import { Subject } from 'rxjs';
 import { FORM_CONTROL_GROUP_INPUT_STATE, FormControlGroupInputState } from '../form-control-group/index';
 import { NgControl } from '@angular/forms';

--- a/lib/ng-vcl/src/select/README.md
+++ b/lib/ng-vcl/src/select/README.md
@@ -35,3 +35,4 @@ Name                  | Type     | Default | Description
 `placeholder`         | string   |         |
 `tabindex`            | number   | 0       | The tabindex of the select
 `search`              | booolean | false   | Enable search capability
+`showSearchIcon`      | boolean  | false   | Prepend search icon to the select input-field input

--- a/lib/ng-vcl/src/select/select.component.html
+++ b/lib/ng-vcl/src/select/select.component.html
@@ -1,34 +1,36 @@
-<ng-content select="vcl-icon[prepend]"></ng-content>
-<input #input
-       [placeholder]="placeholder || ''"
-       [value]="inputValue"
-       [attr.tabindex]="-1"
-       [disabled]="isDisabled"
-       [class.disabled]="isDisabled"
-       [class.readonly]="!search"
-       class="input app-item"
-       role="listbox"
-       autocomplete="off"
-       [readonly]="!search"
-       (keyup)="inputChange($event)"
-       >
-<button *ngIf="clearable && inputValue"
-        vcl-button square
-        type="button"
-        tabindex="-1"
-        class="appended"
-        [disabled]="isDisabled"
-        (click)="clearSelection($event)"
->
-  <vcl-icon icon="vcl:close"></vcl-icon>
-</button>
-<button vcl-button square
-        type="button"
-        tabindex="-1"
-        class="appended"
-      >
-      <vcl-icon icon="vcl:arrow-down"></vcl-icon>
-</button>
+<vcl-input-field class="select">
+  <vcl-icon *ngIf="showSearchIcon" icon="vcl:search"></vcl-icon>
+  <input
+    #input
+    vclInput
+    [placeholder]="placeholder || ''"
+    [value]="inputValue"
+    [attr.tabindex]="-1"
+    [disabled]="isDisabled"
+    [class.disabled]="isDisabled"
+    [class.readonly]="!search"
+    class="input app-item"
+    role="listbox"
+    autocomplete="off"
+    [readonly]="!search"
+    (keyup)="inputChange($event)"
+  />
+  <button
+    *ngIf="clearable && inputValue"
+    vcl-button
+    square
+    type="button"
+    tabindex="-1"
+    class="appended"
+    [disabled]="isDisabled"
+    (click)="clearSelection($event)"
+  >
+    <vcl-icon icon="vcl:close"></vcl-icon>
+  </button>
+  <button vcl-button square type="button" tabindex="-1" class="appended">
+    <vcl-icon icon="vcl:arrow-down"></vcl-icon>
+  </button>
+</vcl-input-field>
 
 <ng-template #innerList>
   <div style="width: 100%" (vclOffClick)="close()">

--- a/lib/ng-vcl/src/select/select.component.scss
+++ b/lib/ng-vcl/src/select/select.component.scss
@@ -1,4 +1,4 @@
-vcl-select {
+:host {
   display: block;
 }
 

--- a/lib/ng-vcl/src/select/select.component.ts
+++ b/lib/ng-vcl/src/select/select.component.ts
@@ -65,7 +65,7 @@ export class SelectComponent extends TemplateLayerRef<any, SelectListItem> imple
   private _valueChangeSub?: Subscription;
   private _focused = false;
   prependedElements = 0;
-
+  
   @ContentChild(SelectListComponent)
   selectList: SelectListComponent;
 
@@ -77,10 +77,6 @@ export class SelectComponent extends TemplateLayerRef<any, SelectListItem> imple
 
   @HostBinding('attr.role')
   attrRole = 'listbox';
-
-  @HostBinding('class.select')
-  @HostBinding('class.input-field')
-  _hostClasses = true;
 
   @Input()
   tabindex = 0;
@@ -99,6 +95,9 @@ export class SelectComponent extends TemplateLayerRef<any, SelectListItem> imple
 
   @Input()
   search = false;
+
+  @Input()
+  showSearchIcon = false;
 
   @Output()
   afterClose = new EventEmitter<any | any[]>();
@@ -333,13 +332,8 @@ export class SelectComponent extends TemplateLayerRef<any, SelectListItem> imple
   }
 
   ngOnInit(): void {
-    if (this.input) {
-      let prependedElements = 0;
-      let sibling: Element = this.input.nativeElement;
-      while ((sibling = sibling.previousElementSibling)) {
-        prependedElements++;
-      }
-      this.prependedElements = prependedElements;
+    if (this.showSearchIcon) {
+      this.prependedElements = 1;
     }
   }
 


### PR DESCRIPTION
### In this iteration, I modified the ```vcl-select``` to use the ```vcl-input-field``` for the selected part of the view

> This also means, that we don't use the slot, instead we defined another ```api``` that shows the search icon which the caller
 might need when using the searchable feature of the ```vcl-select```