### PR TITLE
Utilize the vcl-input-field on the vcl-select

### DIFF
--- a/demo/app/demos/input/demo.component.html
+++ b/demo/app/demos/input/demo.component.html
@@ -15,9 +15,9 @@
 <vcl-form-control-group>
   <vcl-label>Email</vcl-label>
   <vcl-input-field>
-    <vcl-icon icon="mdi:email"></vcl-icon>
+    <vcl-icon vclPrepend icon="mdi:email"></vcl-icon>
     <input vclInput [(ngModel)]="data1" />
-    <button vcl-button square>
+    <button vclAppend vcl-button square>
       <vcl-icon icon="mdi:close"></vcl-icon>
     </button>
   </vcl-input-field>

--- a/demo/app/demos/select/demo.component.html
+++ b/demo/app/demos/select/demo.component.html
@@ -285,7 +285,7 @@
 <vcl-form-control-group>
   <vcl-label>Select country</vcl-label>
   <vcl-select>
-    <vcl-icon prepend icon="vcl:search"></vcl-icon>
+    <vcl-icon vclPrepend icon="vcl:search"></vcl-icon>
     <vcl-select-list [(value)]="value8">
       <vcl-select-list-header>Europe</vcl-select-list-header>
       <vcl-select-list-item value="Greece">

--- a/lib/ng-vcl/src/input/input-field.component.ts
+++ b/lib/ng-vcl/src/input/input-field.component.ts
@@ -6,19 +6,24 @@ import { FORM_CONTROL_EMBEDDED_LABEL_INPUT, EmbeddedInputFieldLabelInput } from 
 
 @Component({
   selector: 'vcl-input-field',
-  template: `<ng-content select="input[vclInput], textarea[vclInput], vcl-icon, vcl-spinner, button[vcl-button]"></ng-content>`,
+  template: `
+    <ng-content vclPrepend select='[vclPrepend]'></ng-content>
+    <ng-content
+      select='input[vclInput], textarea[vclInput], vcl-icon, vcl-spinner, button[vcl-button]'
+    ></ng-content>
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: FORM_CONTROL_EMBEDDED_LABEL_INPUT,
-      useExisting: forwardRef(() => InputFieldComponent)
+      useExisting: forwardRef(() => InputFieldComponent),
     },
-  ]
+  ],
 })
-export class InputFieldComponent implements AfterContentInit, OnDestroy, EmbeddedInputFieldLabelInput {
-  constructor(
-    private cdRef: ChangeDetectorRef,
-  ) { }
+export class InputFieldComponent
+  implements AfterContentInit, OnDestroy, EmbeddedInputFieldLabelInput
+{
+  constructor(private cdRef: ChangeDetectorRef) {}
 
   private stateChangedEmitter = new Subject<void>();
 
@@ -68,7 +73,7 @@ export class InputFieldComponent implements AfterContentInit, OnDestroy, Embedde
 
       let prependedElements = 0;
       let sibling: Element = this.input.elementRef.nativeElement;
-      while (sibling = sibling.previousElementSibling) {
+      while ((sibling = sibling.previousElementSibling)) {
         prependedElements++;
       }
       this.prependedElements = prependedElements;

--- a/lib/ng-vcl/src/input/input-field.component.ts
+++ b/lib/ng-vcl/src/input/input-field.component.ts
@@ -9,8 +9,9 @@ import { FORM_CONTROL_EMBEDDED_LABEL_INPUT, EmbeddedInputFieldLabelInput } from 
   template: `
     <ng-content vclPrepend select='[vclPrepend]'></ng-content>
     <ng-content
-      select='input[vclInput], textarea[vclInput], vcl-icon, vcl-spinner, button[vcl-button]'
+      select='input[vclInput], textarea[vclInput]'
     ></ng-content>
+    <ng-content vclAppend select="[vclAppend]"></ng-content>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [

--- a/lib/ng-vcl/src/select/select.component.html
+++ b/lib/ng-vcl/src/select/select.component.html
@@ -17,6 +17,7 @@
   />
   <button
     *ngIf="clearable && inputValue"
+    vclAppend
     vcl-button
     square
     type="button"
@@ -27,7 +28,7 @@
   >
     <vcl-icon icon="vcl:close"></vcl-icon>
   </button>
-  <button vcl-button square type="button" tabindex="-1" class="appended">
+  <button vclAppend vcl-button square type="button" tabindex="-1" class="appended">
     <vcl-icon icon="vcl:arrow-down"></vcl-icon>
   </button>
 </vcl-input-field>

--- a/lib/ng-vcl/src/select/select.component.html
+++ b/lib/ng-vcl/src/select/select.component.html
@@ -1,34 +1,36 @@
-<ng-content select="vcl-icon[prepend]"></ng-content>
-<input #input
-       [placeholder]="placeholder || ''"
-       [value]="inputValue"
-       [attr.tabindex]="-1"
-       [disabled]="isDisabled"
-       [class.disabled]="isDisabled"
-       [class.readonly]="!search"
-       class="input app-item"
-       role="listbox"
-       autocomplete="off"
-       [readonly]="!search"
-       (keyup)="inputChange($event)"
-       >
-<button *ngIf="clearable && inputValue"
-        vcl-button square
-        type="button"
-        tabindex="-1"
-        class="appended"
-        [disabled]="isDisabled"
-        (click)="clearSelection($event)"
->
-  <vcl-icon icon="vcl:close"></vcl-icon>
-</button>
-<button vcl-button square
-        type="button"
-        tabindex="-1"
-        class="appended"
-      >
-      <vcl-icon icon="vcl:arrow-down"></vcl-icon>
-</button>
+<vcl-input-field>
+  <ng-content vclPrepend select="[vclPrepend]"></ng-content>
+  <input
+    #input
+    vclInput
+    [placeholder]="placeholder || ''"
+    [value]="inputValue"
+    [attr.tabindex]="-1"
+    [disabled]="isDisabled"
+    [class.disabled]="isDisabled"
+    [class.readonly]="!search"
+    class="input app-item"
+    role="listbox"
+    autocomplete="off"
+    [readonly]="!search"
+    (keyup)="inputChange($event)"
+  />
+  <button
+    *ngIf="clearable && inputValue"
+    vcl-button
+    square
+    type="button"
+    tabindex="-1"
+    class="appended"
+    [disabled]="isDisabled"
+    (click)="clearSelection($event)"
+  >
+    <vcl-icon icon="vcl:close"></vcl-icon>
+  </button>
+  <button vcl-button square type="button" tabindex="-1" class="appended">
+    <vcl-icon icon="vcl:arrow-down"></vcl-icon>
+  </button>
+</vcl-input-field>
 
 <ng-template #innerList>
   <div style="width: 100%" (vclOffClick)="close()">

--- a/lib/ng-vcl/src/select/select.component.ts
+++ b/lib/ng-vcl/src/select/select.component.ts
@@ -79,7 +79,6 @@ export class SelectComponent extends TemplateLayerRef<any, SelectListItem> imple
   attrRole = 'listbox';
 
   @HostBinding('class.select')
-  @HostBinding('class.input-field')
   _hostClasses = true;
 
   @Input()


### PR DESCRIPTION
I modified the ```vcl-select``` to use the ```vcl-input-field```. I also modified the ```vcl-input-field``` field to define a vclPrepend  ng-content used by consumers of ```vcl-input-field```.