### PR TITLE
Fixes for calendar, inputs, select, and labels

### DIFF
--- a/demo/app/demos/input/demo.component.html
+++ b/demo/app/demos/input/demo.component.html
@@ -16,7 +16,7 @@
   <vcl-label>Email</vcl-label>
   <vcl-input-field>
     <vcl-icon vclPrepend icon="mdi:email"></vcl-icon>
-    <input vclInput [(ngModel)]="data1" />
+    <input vclInput [(ngModel)]="data2" />
     <button vclAppend vcl-button square>
       <vcl-icon icon="mdi:close"></vcl-icon>
     </button>

--- a/demo/app/demos/input/demo.component.ts
+++ b/demo/app/demos/input/demo.component.ts
@@ -5,4 +5,5 @@ import { Component } from '@angular/core';
 })
 export class InputDemoComponent {
   data1 = '';
+  data2 = '';
 }

--- a/lib/ng-vcl/src/date-picker/date-picker.component.html
+++ b/lib/ng-vcl/src/date-picker/date-picker.component.html
@@ -18,12 +18,12 @@
       <vcl-icon [icon]="pick === 'time' ? 'vcl:clock' : 'vcl:calendar'"></vcl-icon>
 </button>
 
+<!-- VCL OFF Click -->
 <ng-template>
   <vcl-calendar [selectionMode]="pick"
                 [showWeekOfTheYear]="showWeekOfTheYear"
                 [dateModifiers]="dateModifier"
                 [viewDate]="viewDate"
                 [value]="value"
-                (valueChange)="onSelect($event)"
-                (vclOffClick)="close()"></vcl-calendar>
+                (valueChange)="onSelect($event)"></vcl-calendar>
 </ng-template>

--- a/lib/ng-vcl/src/date-picker/date-picker.component.ts
+++ b/lib/ng-vcl/src/date-picker/date-picker.component.ts
@@ -252,6 +252,7 @@ export class DatepickerComponent<VCLDate> extends TemplateLayerRef<any, VCLDate 
   }
 
   onSelect(date: VCLDate) {
+    console.log('something has happened!');
     this.value = date;
     this.updateInput();
     this.valueChange.emit(date);

--- a/lib/ng-vcl/src/input/embedded-label.directive.ts
+++ b/lib/ng-vcl/src/input/embedded-label.directive.ts
@@ -91,6 +91,9 @@ export class EmbeddedInputFieldLabelDirective implements AfterContentInit {
   @HostBinding('style.--prepended-elements')
   prependedElements: number = 0;
 
+  @HostBinding('style.--label-offset-x')
+  labelOffSet = '0em';
+
   ngAfterViewInit() {
     // This workaround disables animations for initial rendering.
     // An initial value provided via ngModel triggers a floating state update shortly after the element is rendered into the DOM
@@ -107,6 +110,9 @@ export class EmbeddedInputFieldLabelDirective implements AfterContentInit {
       this.prependedElements = this.inputField.prependedElements ?? 0;
       this.cdRef.markForCheck();
       this.cdRef.detectChanges();
+      if (this.prependedElements === 0) {
+        this.labelOffSet = '0.6em';
+      }
     }
   }
 

--- a/lib/ng-vcl/src/input/embedded-label.directive.ts
+++ b/lib/ng-vcl/src/input/embedded-label.directive.ts
@@ -91,7 +91,7 @@ export class EmbeddedInputFieldLabelDirective implements AfterContentInit {
   @HostBinding('style.--prepended-elements')
   prependedElements: number = 0;
 
-  @HostBinding('style.--label-offset-x')
+  @HostBinding('style.--floating-label-padding')
   labelOffSet = '0em';
 
   ngAfterViewInit() {

--- a/lib/ng-vcl/src/input/embedded-label.directive.ts
+++ b/lib/ng-vcl/src/input/embedded-label.directive.ts
@@ -7,6 +7,7 @@ export type EmbeddedInputFieldLabelMode = 'float' | 'static' | 'disabled';
 export interface EmbeddedInputFieldLabelInput {
   readonly stateChanged: Observable<void>;
   readonly isLabelFloating: boolean;
+  readonly isFocused: boolean;
   readonly prependedElements?: number;
 }
 
@@ -81,6 +82,9 @@ export class EmbeddedInputFieldLabelDirective implements AfterContentInit {
   @HostBinding('class.floating')
   floating = false;
 
+  @HostBinding('class.focused')
+  focused = false;
+
   @HostBinding('class.disable-animations')
   disableAnimations = true;
 
@@ -99,6 +103,7 @@ export class EmbeddedInputFieldLabelDirective implements AfterContentInit {
   private updateState() {
     if (this.inputField && this.enabled) {
       this.floating = this.inputField?.isLabelFloating ?? false;
+      this.focused = this.inputField?.isFocused ?? false;;
       this.prependedElements = this.inputField.prependedElements ?? 0;
       this.cdRef.markForCheck();
       this.cdRef.detectChanges();


### PR DESCRIPTION
## Here are a summary of the fixes

- Separate binding for email on the input page
- Update the embedded label when input's focus value toggles
- Fix the space between the prepended icon and label  in an input and select form control
- Remove ```vclOffClick```  that hinders selection in ```data-picker``` to change calendar mode