### PR TITLE
feat: add rounded modifier attribute to flipswitch component

### DIFF
--- a/demo/app/demos/flip-switch/demo.component.html
+++ b/demo/app/demos/flip-switch/demo.component.html
@@ -2,6 +2,14 @@
 <vcl-flip-switch [(value)]="value1"></vcl-flip-switch><br>
 Current value: {{value1}}
 
+<h3>Without labels</h3>
+<vcl-flip-switch onLabel="" offLabel="" [(value)]="value4"></vcl-flip-switch><br>
+Current value: {{value3}}
+
+<h3>Round flipswitch</h3>
+<vcl-flip-switch onLabel="" offLabel="" [(value)]="value5" [rounded]="true"></vcl-flip-switch><br>
+Current value: {{value3}}
+
 <h3>With custom labels</h3>
 <vcl-flip-switch onLabel="Yes" offLabel="No" [(value)]="value2"></vcl-flip-switch><br>
 Current value: {{value2}}

--- a/demo/app/demos/flip-switch/demo.component.ts
+++ b/demo/app/demos/flip-switch/demo.component.ts
@@ -7,4 +7,6 @@ export class FlipSwitchDemoComponent {
   value1 = false;
   value2 = false;
   value3 = true;
+  value4 = false;
+  value5 = false;
 }

--- a/lib/ng-vcl/src/flip-switch/README.md
+++ b/lib/ng-vcl/src/flip-switch/README.md
@@ -15,6 +15,7 @@ Name          | Type    | Default | Description
 `value`       | boolean | false   | set the value
 `onLabel`     | string  | 'On'    | The label for "on"
 `offLabel`    | string  | 'Off'   | The label for "off"
+`rounded`     | boolean | false   | Round version of the flipswitch
 
 #### Events
 

--- a/lib/ng-vcl/src/flip-switch/flip-switch.component.ts
+++ b/lib/ng-vcl/src/flip-switch/flip-switch.component.ts
@@ -39,6 +39,10 @@ export class FlipSwitchComponent implements ControlValueAccessor, FormControlGro
   @HostBinding('attr.touch-action')
   _attrTouchAction = 'pan-y';
 
+  @Input()
+  @HostBinding('class.rounded')
+  rounded = false;
+
   private uniqueId = 'vcl_flipswitch_' + UNIQUE_ID++;
 
   private _disabled = false;


### PR DESCRIPTION
> I added a ```rounded``` modifier class that lets the ```flipswitch``` component  have rounded corners and a circular knob