### PR TITLE
fix: 'none' and 'multiple' mode in vcl-data-list

### DIFF
--- a/demo/app/demos/data-list/demo.component.html
+++ b/demo/app/demos/data-list/demo.component.html
@@ -123,3 +123,4 @@ Value: {{value2}}
   </vcl-data-list-item>
   <vcl-busy-indicator class="p-3 w-100p"></vcl-busy-indicator>
 </vcl-data-list>
+

--- a/lib/ng-vcl/src/data-list/README.md
+++ b/lib/ng-vcl/src/data-list/README.md
@@ -25,7 +25,7 @@ Name            | Type                                          | Default     | 
 `value`         | any                                           |             | Current value
 `divider`       | boolean                                       | false       | Show a vertical divider (border) between items when true
 `noBorder`      | boolean                                       | false       | No top/ bottom borders when true
-`mode`          | 'single' \| 'multiple' \| 'none' \| 'content' | 'single'    | `single` allows only one item to be selected. `multi` allows multiple items to be selected. `content` disables item interaction.
+`mode`          | 'single' \| 'multiple' \| 'none'              | 'single'    | `single` allows only one item to be selected. `multi` allows multiple items to be selected. `none` disables item interaction.
 
 ### vcl-data-list events
 

--- a/lib/ng-vcl/src/data-list/data-list-item.directive.ts
+++ b/lib/ng-vcl/src/data-list/data-list-item.directive.ts
@@ -39,7 +39,7 @@ export class DataListItemDirective implements DataListItem, OnDestroy {
 
   @HostBinding('class.selectable')
   get classSelectable() {
-    return !this.isDisabled;
+    return !this.isDisabled  && this.dataList.selectionMode !== 'none';
   }
 
   get isDisabled() {

--- a/lib/ng-vcl/src/data-list/data-list.component.ts
+++ b/lib/ng-vcl/src/data-list/data-list.component.ts
@@ -57,7 +57,7 @@ export class DataListComponent implements DataList, AfterContentInit, OnDestroy,
 
   readonly itemsChange = this._itemsChangeEmitter.asObservable();
 
-  @Input()
+  @Input('mode')
   selectionMode: DataListMode = 'single';
 
   @Input()


### PR DESCRIPTION
Here, I added the ```mode='none'``` to the ```vcl-data-list```  to remove the item interaction. Also made a fix to the multiple items selection mode in the ```vcl-data-list```